### PR TITLE
Adding default arguments for functions

### DIFF
--- a/src/gerber2ems/importer.py
+++ b/src/gerber2ems/importer.py
@@ -200,9 +200,8 @@ def get_vias() -> List[List[float]]:
     return vias
 
 
-def import_stackup():
+def import_stackup(filename = "fab/stackup.json"):
     """Import stackup information from `fab/stackup.json` file and load it into config object."""
-    filename = "fab/stackup.json"
     with open(filename, "r", encoding="utf-8") as file:
         try:
             stackup = json.load(file)


### PR DESCRIPTION
Added a default argument for the import_stackup function instead of assuming that the fab folder exists in the function. 