### PR TITLE
Restrict numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
-dependencies = ["numpy", "matplotlib", "coloredlogs", "nanomesh", "scikit-rf", "Pillow", "scipy", "pyserde"]
+dependencies = ["numpy<2", "matplotlib", "coloredlogs", "nanomesh", "scikit-rf", "Pillow", "scipy", "pyserde"]
 scripts = {gerber2ems = "gerber2ems.main:main", ems2paraview = "ems2paraview.main:main"}
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Hello,

`gerber2ems` does not seem to be compatible with Numpy 2. This PR forbids Numpy 2 versions.